### PR TITLE
Make some of the enum collections safer

### DIFF
--- a/src/main/java/io/github/dsh105/echopet/entity/PetData.java
+++ b/src/main/java/io/github/dsh105/echopet/entity/PetData.java
@@ -1,7 +1,8 @@
 package io.github.dsh105.echopet.entity;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 public enum PetData {
 
@@ -67,18 +68,18 @@ public enum PetData {
 
 
     private String configOptionString;
-    private ArrayList<Type> t = new ArrayList<Type>();
+    private List<Type> t;
 
     PetData(String configOptionString, Type... t) {
         this.configOptionString = configOptionString;
-        this.t.addAll(Arrays.asList(t));
+        this.t = ImmutableList.copyOf(t);
     }
 
     public String getConfigOptionString() {
         return this.configOptionString;
     }
 
-    public ArrayList<Type> getTypes() {
+    public List<Type> getTypes() {
         return this.t;
     }
 

--- a/src/main/java/io/github/dsh105/echopet/entity/PetType.java
+++ b/src/main/java/io/github/dsh105/echopet/entity/PetType.java
@@ -1,6 +1,7 @@
 package io.github.dsh105.echopet.entity;
 
 import com.dsh105.dshutils.logger.Logger;
+import com.google.common.collect.ImmutableList;
 import io.github.dsh105.echopet.EchoPetPlugin;
 import io.github.dsh105.echopet.entity.type.bat.BatPet;
 import io.github.dsh105.echopet.entity.type.bat.CraftBatPet;
@@ -98,7 +99,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
 import java.util.List;
 
 public enum PetType {
@@ -174,7 +174,7 @@ public enum PetType {
         this.petClass = petClass;
         this.craftClass = craftClass;
         this.id = registrationId;
-        this.allowedData = Arrays.asList(allowedData);
+        this.allowedData = ImmutableList.copyOf(allowedData);
         this.maxHealth = maxHealth;
         this.attackDamage = attackDamage;
         this.entityType = entityType;


### PR DESCRIPTION
This starts part of my work on improving EchoPet code. This is not as major as the SQL support rewrite I did, and mostly has positive benefits.

By using immutable collections, we shield against odd data being inserted, which could cause... interesting behavior. Better safe than sorry.
