### PR TITLE
Unregister the commands when the plugin disables.

### DIFF
--- a/src/main/java/io/github/dsh105/echopet/EchoPetPlugin.java
+++ b/src/main/java/io/github/dsh105/echopet/EchoPetPlugin.java
@@ -267,6 +267,9 @@ public class EchoPetPlugin extends DSHPlugin {
             dbPool.shutdown();
         }
 
+        // Unregister the commands
+        this.COMMAND_MANAGER.unregister();
+
         // Don't nullify instance until after we're done
         super.onDisable();
     }


### PR DESCRIPTION
In it's current state EchoPet won't unregister it's commands when it disables. This may cause trouble so better make use of the provided "unregister()" method in CommandManager.
