### PR TITLE
Fix the return type of UUIDMigration#getIdentificationFor(Player)

### DIFF
--- a/modules/API/src/main/java/com/dsh105/echopet/compat/api/plugin/uuid/UUIDMigration.java
+++ b/modules/API/src/main/java/com/dsh105/echopet/compat/api/plugin/uuid/UUIDMigration.java
@@ -31,9 +31,9 @@ import java.util.UUID;
 
 public class UUIDMigration {
 
-    public static String getIdentificationFor(Player player) {
+    public static Object getIdentificationFor(Player player) {
         if (ReflectionUtil.MC_VERSION_NUMERIC >= 172) {
-            return player.getUniqueId().toString();
+            return player.getUniqueId();
         } else {
             return player.getName();
         }

--- a/modules/EchoPet/src/main/java/com/dsh105/echopet/api/SqlPetManager.java
+++ b/modules/EchoPet/src/main/java/com/dsh105/echopet/api/SqlPetManager.java
@@ -88,7 +88,7 @@ public class SqlPetManager implements ISqlPetManager {
                     else
                         ps = con.prepareStatement("INSERT INTO Pets (Owner, PetType, PetName) VALUES (?, ?, ?)");
 
-                    ps.setString(1, UUIDMigration.getIdentificationFor(p.getOwner()));
+                    ps.setString(1, String.valueOf(UUIDMigration.getIdentificationFor(p.getOwner())));
                     ps.setString(2, p.getPetType().toString());
                     ps.setString(3, p.getPetName());
                     ps.executeUpdate();
@@ -128,7 +128,7 @@ public class SqlPetManager implements ISqlPetManager {
                 try {
                     con = EchoPet.getPlugin().getDbPool().getConnection();
                     ps = con.prepareStatement("SELECT * FROM Pets WHERE Owner = ?;");
-                    ps.setString(1, UUIDMigration.getIdentificationFor(player));
+                    ps.setString(1, String.valueOf(UUIDMigration.getIdentificationFor(player)));
                     ResultSet rs = ps.executeQuery();
                     while (rs.next()) {
                         owner = Bukkit.getPlayerExact(rs.getString("Owner"));
@@ -214,7 +214,7 @@ public class SqlPetManager implements ISqlPetManager {
                 try {
                     con = EchoPet.getPlugin().getDbPool().getConnection();
                     ps = con.prepareStatement("DELETE FROM Pets WHERE Owner = ?;");
-                    ps.setString(1, UUIDMigration.getIdentificationFor(player));
+                    ps.setString(1, String.valueOf(UUIDMigration.getIdentificationFor(player)));
                     ps.executeUpdate();
                 } catch (SQLException e) {
                     Logger.log(Logger.LogLevel.SEVERE, "Failed to retrieve Pet data for " + player.getName() + " in MySQL Database", e, true);
@@ -243,7 +243,7 @@ public class SqlPetManager implements ISqlPetManager {
                     String list = SQLUtil.serialiseUpdate(Arrays.asList(PetData.values()), true);
                     ps = con.prepareStatement("UPDATE Pets SET ? WHERE Owner = ?;");
                     ps.setString(1, list);
-                    ps.setString(2, UUIDMigration.getIdentificationFor(player));
+                    ps.setString(2, String.valueOf(UUIDMigration.getIdentificationFor(player)));
                     ps.executeUpdate();
                 } catch (SQLException e) {
                     Logger.log(Logger.LogLevel.SEVERE, "Failed to retrieve Pet data for " + player.getName() + " in MySQL Database", e, true);


### PR DESCRIPTION
Because this method returned a String instead of a UUID, Pet#getOwner()
did not work properly: `ownerIdentification` was always a String as of
[Pet.java:92](https://github.com/DSH105/EchoPet/blob/5a2b59b1cec6ac91a18e566b6b5e50db5f5d495a/modules/EchoPet/src/main/java/com/dsh105/echopet/api/pet/Pet.java#L92)
