### PR TITLE
Add null check pointer to prevent crashes.

### DIFF
--- a/modules/v1_6_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_6_R3/entity/EntityPet.java
+++ b/modules/v1_6_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_6_R3/entity/EntityPet.java
@@ -379,7 +379,7 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
         super.e(moveEvent.getSidewardMotionSpeed(), moveEvent.getForwardMotionSpeed());
 
         PetType pt = this.getPet().getPetType();
-        if (FIELD_JUMP != null) {
+        if (FIELD_JUMP != null && this.passenger != null) {
             if (EchoPet.getOptions().canFly(pt)) {
                 try {
                     if (((Player) (human.getBukkitEntity())).isFlying()) {

--- a/modules/v1_7_R1/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R1/entity/EntityPet.java
+++ b/modules/v1_7_R1/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R1/entity/EntityPet.java
@@ -381,7 +381,7 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
         super.e(moveEvent.getSidewardMotionSpeed(), moveEvent.getForwardMotionSpeed());
 
         PetType pt = this.getPet().getPetType();
-        if (FIELD_JUMP != null) {
+        if (FIELD_JUMP != null && this.passenger != null) {
             if (EchoPet.getOptions().canFly(pt)) {
                 try {
                     if (((Player) (human.getBukkitEntity())).isFlying()) {

--- a/modules/v1_7_R2/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R2/entity/EntityPet.java
+++ b/modules/v1_7_R2/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R2/entity/EntityPet.java
@@ -381,7 +381,7 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
         super.e(moveEvent.getSidewardMotionSpeed(), moveEvent.getForwardMotionSpeed());
 
         PetType pt = this.getPet().getPetType();
-        if (FIELD_JUMP != null) {
+        if (FIELD_JUMP != null && this.passenger != null) {
             if (EchoPet.getOptions().canFly(pt)) {
                 try {
                     if (((Player) (human.getBukkitEntity())).isFlying()) {

--- a/modules/v1_7_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R3/entity/EntityPet.java
+++ b/modules/v1_7_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R3/entity/EntityPet.java
@@ -381,7 +381,7 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
         super.e(moveEvent.getSidewardMotionSpeed(), moveEvent.getForwardMotionSpeed());
 
         PetType pt = this.getPet().getPetType();
-        if (FIELD_JUMP != null) {
+        if (FIELD_JUMP != null && this.passenger != null) {
             if (EchoPet.getOptions().canFly(pt)) {
                 try {
                     if (((Player) (human.getBukkitEntity())).isFlying()) {


### PR DESCRIPTION
Add null check pointer to prevent crashes when an player stops riding an entity due to events inside the entity tick loop.
Null-pointer exceptions (and following crash) were caused by [MyWarp] signs triggering by redstone inside the entity loop (Player was teleported during the entity tick, causing it to stop riding an entity).
