### PR TITLE
Check for player dismount when EntityPet updates. Fixes #323

### DIFF
--- a/modules/EchoPet/src/main/java/com/dsh105/echopet/api/pet/Pet.java
+++ b/modules/EchoPet/src/main/java/com/dsh105/echopet/api/pet/Pet.java
@@ -260,10 +260,12 @@ public abstract class Pet implements IPet {
 
     @Override
     public void ownerRidePet(boolean flag) {
-        this.ownerIsMounting = true;
         if (this.ownerRiding == flag) {
             return;
         }
+
+        this.ownerIsMounting = true;
+
         if (this.isHat) {
             this.setAsHat(false);
         }

--- a/modules/v1_6_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_6_R3/entity/EntityPet.java
+++ b/modules/v1_6_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_6_R3/entity/EntityPet.java
@@ -291,6 +291,10 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
             return;
         }
 
+        if (pet.isOwnerRiding() && this.passenger == null && !pet.isOwnerInMountingProcess()) {
+            pet.ownerRidePet(false);
+        }
+
         if (((CraftPlayer) this.getPlayerOwner()).getHandle().isInvisible() != this.isInvisible() && !this.shouldVanish) {
             this.setInvisible(!this.isInvisible());
         }

--- a/modules/v1_7_R1/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R1/entity/EntityPet.java
+++ b/modules/v1_7_R1/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R1/entity/EntityPet.java
@@ -292,6 +292,10 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
             return;
         }
 
+        if (pet.isOwnerRiding() && this.passenger == null && !pet.isOwnerInMountingProcess()) {
+            pet.ownerRidePet(false);
+        }
+
         if (((CraftPlayer) this.getPlayerOwner()).getHandle().isInvisible() != this.isInvisible() && !this.shouldVanish) {
             this.setInvisible(!this.isInvisible());
         }

--- a/modules/v1_7_R2/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R2/entity/EntityPet.java
+++ b/modules/v1_7_R2/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R2/entity/EntityPet.java
@@ -292,6 +292,10 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
             return;
         }
 
+        if (pet.isOwnerRiding() && this.passenger == null && !pet.isOwnerInMountingProcess()) {
+            pet.ownerRidePet(false);
+        }
+
         if (((CraftPlayer) this.getPlayerOwner()).getHandle().isInvisible() != this.isInvisible() && !this.shouldVanish) {
             this.setInvisible(!this.isInvisible());
         }

--- a/modules/v1_7_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R3/entity/EntityPet.java
+++ b/modules/v1_7_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_7_R3/entity/EntityPet.java
@@ -293,6 +293,10 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
             return;
         }
 
+        if (pet.isOwnerRiding() && this.passenger == null && !pet.isOwnerInMountingProcess()) {
+            pet.ownerRidePet(false);
+        }
+
         if (((CraftPlayer) this.getPlayerOwner()).getHandle().isInvisible() != this.isInvisible() && !this.shouldVanish) {
             this.setInvisible(!this.isInvisible());
         }


### PR DESCRIPTION
Previous to these changes there were no checks for player dismount, leading to an issue where the player's fall damage would be cancelled despite no longer riding a pet.
