### PR TITLE
Fix pets not coming back on respawn

### DIFF
--- a/modules/EchoPet/src/main/java/com/dsh105/echopet/listeners/PetOwnerListener.java
+++ b/modules/EchoPet/src/main/java/com/dsh105/echopet/listeners/PetOwnerListener.java
@@ -208,8 +208,7 @@ public class PetOwnerListener implements Listener {
         new BukkitRunnable() { 
             
             @Override
-            public void run()
-            {
+            public void run() {
                 EchoPet.getManager().loadPets(p, true, false, true);
             }
             


### PR DESCRIPTION
You need to make it wait a bit after the player respawn, otherwise the pet isn't there when the player respawns.

I'm not entirely sure why this fixes it, but it appears to fix it.
