### PR TITLE
Add regex config to do regex matching on pet names so word filters can be created.

### DIFF
--- a/modules/API/src/main/java/com/dsh105/echopet/compat/api/config/ConfigOptions.java
+++ b/modules/API/src/main/java/com/dsh105/echopet/compat/api/config/ConfigOptions.java
@@ -27,6 +27,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 
 public class ConfigOptions extends Options {
 
@@ -106,7 +109,15 @@ public class ConfigOptions extends Options {
 
         set("petNames.My Pet", "allow");
         set("petNamesRegexMatching", true);
-        set("petNamesRegex.*fuck*", "deny");
+        set("petNamesRegex", new ArrayList<HashMap<String, String>>() {
+            {
+                add(new HashMap<String, String>(){
+                    {
+                        put(".*administrator.*", "deny");
+                    }
+                });
+            }
+        });
         set("stripDiacriticsFromNames", true);
 
         set("enableHumanSkinFixing", true, "Connects to Mojang session servers to attempt fto fix human skins");

--- a/modules/API/src/main/java/com/dsh105/echopet/compat/api/util/PetNames.java
+++ b/modules/API/src/main/java/com/dsh105/echopet/compat/api/util/PetNames.java
@@ -23,6 +23,9 @@ import com.dsh105.echopet.compat.api.entity.IPet;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.List;
+import java.util.Map;
+
 public class PetNames {
 
     public static boolean allow(String input, IPet pet) {
@@ -39,12 +42,15 @@ public class PetNames {
         }
 
         if (config.getBoolean("petNamesRegexMatching")) {
-            ConfigurationSection csRegex = config.getConfigurationSection("petNamesRegex");
-            if (csRegex != null) {
-                for (String key : csRegex.getKeys(false)) {
-                    if (key.matches(nameToCheck)) {
-                        String value = config.getString("petNames." + key);
-                        return pet.getOwner().hasPermission("echopet.pet.name.override") || !(value.equalsIgnoreCase("deny") || value.equalsIgnoreCase("false"));
+            List<Map<String, String>> csRegex = (List<Map<String, String>>) config.get("petNamesRegex");
+            if (!csRegex.isEmpty()) {
+                for (Map<String, String> regexMap : csRegex) {
+                    for (Map.Entry<String, String> entry : regexMap.entrySet()) {
+                        if (nameToCheck.matches(entry.getKey())) {
+                            return pet.getOwner().hasPermission("echopet.pet.name.override")
+                                    || !(entry.getValue().equalsIgnoreCase("deny")
+                                    || entry.getValue().equalsIgnoreCase("false"));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Add the ability to regex match names so that filters can be made to prevent profanities or admin/staff impersonation.
