### PR TITLE
Fix Spigot-1.7/1.8 protocol patch compatibility

### DIFF
--- a/modules/API/src/main/java/com/dsh105/echopet/compat/api/util/ReflectionUtil.java
+++ b/modules/API/src/main/java/com/dsh105/echopet/compat/api/util/ReflectionUtil.java
@@ -37,10 +37,12 @@ public class ReflectionUtil {
 
     private static String prepareCompatNmsPath() {
         String versionTag = getServerVersion();
-        if (Bukkit.getVersion().contains("Spigot") && versionTag.equals("v1_7_R4") && isSpigot1dot8()) {
-            // At least it works
-            versionTag = "v1_8_Spigot";
-        }
+
+//        if (Bukkit.getVersion().contains("Spigot") && versionTag.equals("v1_7_R4") && isSpigot1dot8()) {
+//            // At least it works
+//            versionTag = "v1_8_Spigot";
+//        }
+
         return "com.dsh105.echopet.compat.nms." + versionTag;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,13 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
         </plugins>
 
         <extensions>


### PR DESCRIPTION
'v1_8_Spigot' was removed in 07f71f5, it should point to 'v1_7_R4' instead as of the new ProtocolLib Spigot hack listener thingy.

Oh and I set up Maven to use Java 6 because it was giving me errors without it, you can leave it out if you want.

Fixes  #537