### PR TITLE
Optimize performance of InventoryMenu.onInvClick(InventoryClickEvent)

### DIFF
--- a/modules/API/src/main/java/com/dsh105/echopet/compat/api/util/inventory/InventoryMenu.java
+++ b/modules/API/src/main/java/com/dsh105/echopet/compat/api/util/inventory/InventoryMenu.java
@@ -95,7 +95,7 @@ public class InventoryMenu implements InventoryHolder, Listener {
         HumanEntity human = event.getWhoClicked();
         if (human instanceof Player) {
             Player player = (Player) human;
-            Inventory inv = player.getOpenInventory().getTopInventory();
+            Inventory inv = event.getView().getTopInventory();
             if (inv.getHolder() != null && inv.getHolder() instanceof InventoryMenu && event.getRawSlot() >= 0 && event.getRawSlot() < size) {
                 InventoryMenu menu = (InventoryMenu) inv.getHolder();
                 if (menu.id == id) {


### PR DESCRIPTION
Java profiler is telling me that particular line is taking up a lot of CPU time. Inventory events all have the InventoryView already, so it is unnecessary to recalculate it by calling player.getOpenInventory().