### PR TITLE
Pull Req - Add support for invisible pets with a forceInvisible bool

### DIFF
--- a/modules/v1_8_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_8_R3/entity/EntityPet.java
+++ b/modules/v1_8_R3/src/main/java/com/dsh105/echopet/compat/nms/v1_8_R3/entity/EntityPet.java
@@ -58,6 +58,7 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
     protected float rideSpeed;
     public EntityLiving goalTarget = null;
     public boolean shouldVanish;
+    public boolean forceInvisible;
 
     public EntityPet(World world) {
         super(world);
@@ -304,7 +305,10 @@ public abstract class EntityPet extends EntityCreature implements IAnimal, IEnti
         }
 
         if (((CraftPlayer) this.getPlayerOwner()).getHandle().isInvisible() != this.isInvisible() && !this.shouldVanish) {
-            this.setInvisible(!this.isInvisible());
+            if (forceInvisible && !this.isInvisible())
+            	this.setInvisible(forceInvisible)
+            else
+            	this.setInvisible(!this.isInvisible());
         }
 
         if (((CraftPlayer) this.getPlayerOwner()).getHandle().isSneaking() != this.isSneaking()) {


### PR DESCRIPTION
The onLive() method conflicts with the setInvisible(bool) method when
the pet's owner is not also visible/invisible. This new parameter allows
developers using the API to force the pet to be invisible regardless of
the pet owner's state.